### PR TITLE
Refactor bf methods, increase BeamSearch discovery area

### DIFF
--- a/src/mmwave/model/mmwave-3gpp-channel.cc
+++ b/src/mmwave/model/mmwave-3gpp-channel.cc
@@ -496,7 +496,7 @@ MmWave3gppChannel::DoCalcRxPowerSpectralDensity (Ptr<const SpectrumValue> txPsd,
 			}
 			else
 			{
-				LongTermCovarianceBeamforming (channelParams);
+				LongTermCovMatrixBeamforming (channelParams);
 			}
 			txAntennaArray->SetBeamformingVector (channelParams->m_txW, rxDevice);
 			rxAntennaArray->SetBeamformingVector (channelParams->m_rxW, txDevice);
@@ -541,7 +541,7 @@ MmWave3gppChannel::DoCalcRxPowerSpectralDensity (Ptr<const SpectrumValue> txPsd,
 }
 
 void
-MmWave3gppChannel::LongTermCovarianceBeamforming(Ptr<Params3gpp> params) const
+MmWave3gppChannel::LongTermCovMatrixBeamforming(Ptr<Params3gpp> params) const
 {
 	//generate transmitter side spatial correlation matrix
 	uint8_t txSize = params->m_channel.at(0).size();
@@ -2432,14 +2432,14 @@ MmWave3gppChannel::BeamSearchBeamforming (Ptr<const SpectrumValue> txPsd, Ptr<Pa
 		Ptr<AntennaArrayModel> rxAntenna, uint8_t *txAntennaNum, uint8_t *rxAntennaNum) const
 {
 	double max = 0, maxTx = 0, maxRx =0, maxTxTheta, maxRxTheta;
-	NS_LOG_UNCOND("CellScan method at time " << Simulator::Now().GetSeconds());
+	NS_LOG_LOGIC("BeamSearchBeamforming method at time " << Simulator::Now().GetSeconds());
 	for (uint16_t txTheta = 60; txTheta < 121; txTheta=txTheta+10)
 	{
-		for(uint16_t tx=0; tx<=2*txAntennaNum[1]; tx++)
+		for(uint16_t tx=0; tx<=txAntennaNum[1]; tx++)
 		{
 			for (uint16_t rxTheta = 60; rxTheta < 121; rxTheta=rxTheta+10)
 			{
-				for(uint16_t rx=0; rx<=2*rxAntennaNum[1]; rx++)
+				for(uint16_t rx=0; rx<=rxAntennaNum[1]; rx++)
 				{
 					NS_LOG_LOGIC("txTheta " << txTheta << " rxTheta " << rxTheta << " tx sector " << 
 						(M_PI*(double)tx/(double)txAntennaNum[1]-0.5*M_PI)/(M_PI)*180 << " rx sector " << 
@@ -2456,6 +2456,7 @@ MmWave3gppChannel::BeamSearchBeamforming (Ptr<const SpectrumValue> txPsd, Ptr<Pa
 					uint8_t nbands = bfGain.GetSpectrumModel ()->GetNumBands ();
 					double power = Sum (bfGain)/nbands;
 
+					NS_LOG_LOGIC("gain " << power);
 					if (max < power)
 					{
 						max = power;

--- a/src/mmwave/model/mmwave-3gpp-channel.h
+++ b/src/mmwave/model/mmwave-3gpp-channel.h
@@ -275,14 +275,14 @@ private:
 	 * The vector is stored in the Params3gpp object passed as parameter
 	 * @params the channel realizationin as a Params3gpp object
 	 */
-	void PowerMethodBeamforming (Ptr<Params3gpp> params) const;
+	void LongTermCovarianceBeamforming (Ptr<Params3gpp> params) const;
 	
 	/**
 	 * Scan all sectors with predefined code book and select the one returns maximum gain.
 	 * The BF vector is stored in the Params3gpp object passed as parameter
 	 * @params the channel realizationin as a Params3gpp object
 	 */
-	void CellScan (Ptr<const SpectrumValue> txPsd, Ptr<Params3gpp> params, Ptr<AntennaArrayModel> txAntenna,
+	void BeamSearchBeamforming (Ptr<const SpectrumValue> txPsd, Ptr<Params3gpp> params, Ptr<AntennaArrayModel> txAntenna,
 			Ptr<AntennaArrayModel> rxAntenna, uint8_t *txAntennaNum, uint8_t *rxAntennaNum) const;
 
 

--- a/src/mmwave/model/mmwave-3gpp-channel.h
+++ b/src/mmwave/model/mmwave-3gpp-channel.h
@@ -275,7 +275,7 @@ private:
 	 * The vector is stored in the Params3gpp object passed as parameter
 	 * @params the channel realizationin as a Params3gpp object
 	 */
-	void LongTermCovarianceBeamforming (Ptr<Params3gpp> params) const;
+	void LongTermCovMatrixBeamforming (Ptr<Params3gpp> params) const;
 	
 	/**
 	 * Scan all sectors with predefined code book and select the one returns maximum gain.


### PR DESCRIPTION
I changed the names of the methods to perform BF, and increased the discovery area of the BeamSearch method (on the horizontal plane it now scans from -90 to 270 degrees).